### PR TITLE
Update microduck-replica entry

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -115,7 +115,7 @@ Ways for LLM agents and scripts to drive a duck.
 
 The hardware is not open source (no BOM, CAD or PCB files), but the MJCF and STL meshes are public.
 
-- [microduck-replica](https://github.com/fanhao375/microduck-replica) - Mechanical reconstruction study: assembly and exploded drawings and CAD-importable assemblies derived from the public MJCF/STL model. In Chinese.
+- [microduck-replica](https://github.com/fanhao375/microduck-replica) - Reconstruction study deriving assembly and exploded drawings, CAD-importable assemblies, a fastener list and an electronics teardown (Radxa Zero 3W, TTL servo bus, the two custom boards) from the public MJCF, STL meshes and runtime source, in English and Chinese and not verified against physical hardware.
 
 ## Articles and Coverage
 


### PR DESCRIPTION
Updating my own entry — **I am the author.**

**What it does:** derives assembly and exploded drawings, CAD-importable assemblies (world transforms applied, so parts land in place instead of stacking at the origin), a fastener list reverse-engineered from hole features, and an electronics teardown recovered by reading the runtime source — all from the public MJCF, STL meshes and Rust sources.

**Why the description changed:** the current line predates most of the work. Since it was written the repo added an electronics teardown (main board identified as a Radxa Zero 3W, the TTL half-duplex servo bus and its protocol, and the two custom boards with their chips and addresses), a fastener reconstruction, and an English readme — so "Mechanical reconstruction study … In Chinese." is no longer accurate on either count.

**On the honesty rule:** everything is derived from published files and source and is **not verified against physical hardware** — no units have shipped yet. The new description says so explicitly, per the contributing guidelines. The Radxa Zero 3W conclusion was independently reached by [@tspy on X](https://x.com/tspy/status/2094249218735300630) on 2026-08-31.

**Lint:** `npx awesome-lint` fails locally on Windows with `Invalid GitHub repo URL: <local path>`; it fails identically on an unmodified checkout, so it is environmental rather than caused by this change. The edited line follows the format rules — one sentence, capitalized, ends with a period, no trailing whitespace, no hard wrap.